### PR TITLE
Return the promise created by the httpClient to errors to bubble up.

### DIFF
--- a/Source/commands/CommandCoordinator.js
+++ b/Source/commands/CommandCoordinator.js
@@ -14,16 +14,13 @@ export class CommandCoordinator
     }
 
     handle(command) {
-        let promise = new Promise((resolve, reject) => {
-            this._httpClient.createRequest('/api/Dolittle/Commands')
+        return this._httpClient.createRequest('/api/Dolittle/Commands')
             .asPost()
             .withContent(CommandRequest.createFrom(command))
             .send()
             .then(result => {
                 let commandResult = JSON.parse(result.response);
-                resolve(commandResult);
+                return commandResult;
             });
-        });
-        return promise;
     }
 }

--- a/Source/queries/QueryCoordinator.js
+++ b/Source/queries/QueryCoordinator.js
@@ -14,16 +14,13 @@ export class QueryCoordinator {
     }
 
     execute(query) {
-        let promise = new Promise((resolve, reject) => {
-            this._httpClient.createRequest('/api/Dolittle/Queries')
+        return this._httpClient.createRequest('/api/Dolittle/Queries')
             .asPost()
             .withContent(QueryRequest.createFrom(query))
             .send()
             .then(result => {
                 let queryResult = JSON.parse(result.response);
-                resolve(queryResult);
+                return queryResult;
             });
-        });
-        return promise;
     }
 }


### PR DESCRIPTION
Errors thrown by the httpClient aren't catchable from client code using:
CommandCoordinator.execute() and QueryCoordinator.execute()

Not sure if this is how to handle this, but it's an attempt to resolve #1 by returning the underlying promise from httpClient. Also changed this for the CommandCoordinator, since it's following the same pattern.