### PR TITLE
Send cookies from same-origin when fetching

### DIFF
--- a/Source/commands/CommandCoordinator.js
+++ b/Source/commands/CommandCoordinator.js
@@ -17,6 +17,7 @@ export class CommandCoordinator {
      */
     handle(command) {
         return fetch(`${CommandCoordinator.apiBaseUrl}/api/Dolittle/Commands`, {
+            credentials: 'same-origin',
             method: 'POST',
             body: JSON.stringify(CommandRequest.createFrom(command)),
             headers: {

--- a/Source/commands/package.json
+++ b/Source/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dolittle/commands",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/Source/queries/QueryCoordinator.js
+++ b/Source/queries/QueryCoordinator.js
@@ -17,6 +17,7 @@ export class QueryCoordinator {
      */
     execute(query) {
         return fetch(`${QueryCoordinator.apiBaseUrl}/api/Dolittle/Queries`, {
+            credentials: 'same-origin',
             method: 'POST',
             body: JSON.stringify(QueryRequest.createFrom(query)),
             headers: {

--- a/Source/queries/package.json
+++ b/Source/queries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dolittle/queries",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This is the default in new browsers, but old browsers default to “omit”, which doesn’t send anything

This closes #6 